### PR TITLE
Implement high-level topic producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -49,6 +49,12 @@ name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "autocfg"
@@ -79,10 +85,11 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -91,6 +98,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "crc"
@@ -291,6 +307,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "kafka-protocol"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,17 +380,21 @@ dependencies = [
 
 [[package]]
 name = "kafka-rs"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bytes",
+ "chrono",
  "futures",
  "kafka-protocol",
  "socket2",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -421,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -438,6 +478,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -511,7 +560,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -526,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -623,6 +672,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -752,6 +821,9 @@ name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka-rs"
 description = "Native Rust Kafka client, built upon kafka-protocol-rs and Tokio."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>"]
@@ -12,14 +12,18 @@ keywords = ["kafka", "streaming", "message-queue", "async"]
 rust-version = "1.76.0"
 
 [dependencies]
-anyhow = { version = "1.0.80", default-features = false, features = ["std"] }
-bytes = { version = "1.5.0", default-features = false, features = ["std"] }
-futures = { version = "0.3.30", default-features = false, features = ["std"] }
+anyhow = { version = "1", default-features = false, features = ["std"] }
+arc-swap = { version = "1", default-features = false }
+bytes = { version = "1", default-features = false, features = ["std"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
+futures = { version = "0.3", default-features = false, features = ["std"] }
 kafka-protocol = { version = "0.9", default-features = false }
-socket2 = { version = "0.5.6", default-features = false }
+socket2 = { version = "0.5", default-features = false }
+thiserror = { version = "1", default-features = false }
 tokio = { version = "1", default-features = false, features = ["io-util", "rt", "net", "macros", "sync", "time"] }
-tokio-util = { version = "0.7.10", default-features = false, features = ["codec", "net", "time", "rt"] }
-tracing = { version = "0.1.40", default-features = false, features = ["std", "log", "attributes"] }
+tokio-util = { version = "0.7", default-features = false, features = ["codec", "net", "time", "rt"] }
+tracing = { version = "0.1", default-features = false, features = ["std", "log", "attributes"] }
+uuid = { version = "1", default-features = false, features = ["v4", "std"] }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "registry"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,19 +2,46 @@
 
 use std::sync::Arc;
 
+use bytes::{Bytes, BytesMut};
+use kafka_protocol::{
+    indexmap::IndexMap,
+    messages::{produce_request::PartitionProduceData, BrokerId, ProduceRequest},
+    protocol::StrBytes,
+    records::{Compression, Record, RecordBatchEncoder, RecordEncodeOptions, TimestampType},
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, DropGuard};
 
-use crate::clitask::{ClientMsg, ClientTask};
+use crate::{
+    broker::{BrokerRequestError, BrokerResponse},
+    clitask::{ClientTask, ClusterMeta, Msg},
+};
+
+/*
+- TODO: build a TopicBatcher on top of a TopicProducer which works like a sink,
+  batches based on configured max size, will handle retries, and the other good stuff.
+*/
+
+/// The default timeout used for requests (10s).
+pub const DEFAULT_TIMEOUT: i32 = 10 * 1000;
+
+/// Client results from interaction with a Kafka cluster.
+pub type Result<T> = std::result::Result<T, ClientError>;
+/// Headers of a message.
+pub type MessageHeaders = IndexMap<StrBytes, Option<Bytes>>;
 
 /// A Kafka client.
 ///
-/// This client is `Send + Sync + Clone`, and cloning the client to share it among application
+/// This client is `Send + Sync + Clone`, and cloning this client to share it among application
 /// tasks is encouraged.
 #[derive(Clone)]
 pub struct Client {
     /// The channel used for communicating with the client task.
-    tx: mpsc::Sender<ClientMsg>,
+    _tx: mpsc::Sender<Msg>,
+    /// Discovered metadata on a Kafka cluster along with broker connections.
+    ///
+    /// NOTE WELL: this value should never be updated outside of the `ClientTask`.
+    cluster: ClusterMeta,
     /// The shutdown signal for this client, which will be triggered once all client handles are dropped.
     _shutdown: Arc<DropGuard>,
 }
@@ -25,10 +52,214 @@ impl Client {
         let (tx, rx) = mpsc::channel(1_000);
         let shutdown = CancellationToken::new();
         let task = ClientTask::new(seed_list, rx, shutdown.clone());
+        let topics = task.cluster.clone();
         tokio::spawn(task.run());
         Self {
-            tx,
+            _tx: tx,
+            cluster: topics,
             _shutdown: Arc::new(shutdown.drop_guard()),
         }
+    }
+
+    /// Build a producer for a topic.
+    pub fn topic_producer(&self, topic: &str, acks: Acks, timeout_ms: Option<i32>, compression: Option<Compression>) -> TopicProducer {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let compression = compression.unwrap_or(Compression::None);
+        let encode_opts = RecordEncodeOptions { version: 2, compression };
+        TopicProducer {
+            _client: self.clone(),
+            tx,
+            rx,
+            cluster: self.cluster.clone(),
+            topic: StrBytes::from_string(topic.into()),
+            acks,
+            timeout_ms: timeout_ms.unwrap_or(DEFAULT_TIMEOUT),
+            encode_opts,
+            buf: BytesMut::with_capacity(1024 * 1024),
+            batch_buf: Vec::with_capacity(1024),
+            last_ptn: -1,
+        }
+    }
+}
+
+/// A message to be encoded as a Kafka record within a record batch.
+pub struct Message {
+    /// An optional key for the record.
+    pub key: Option<Bytes>,
+    /// An optional value as the body of the record.
+    pub value: Option<Bytes>,
+    /// Optional headers to be included in the record.
+    pub headers: MessageHeaders,
+}
+
+impl Message {
+    /// Construct a new record.
+    pub fn new(key: Option<Bytes>, value: Option<Bytes>, headers: MessageHeaders) -> Self {
+        Self { key, value, headers }
+    }
+}
+
+/// Write acknowledgements required for a request.
+#[derive(Clone, Copy)]
+#[repr(i16)]
+pub enum Acks {
+    /// Leader and replicas.
+    All = -1,
+    /// None.
+    None = 0,
+    /// Leader only.
+    Leader = 1,
+}
+
+/// Client errors from interacting with a Kafka cluster.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    /// Error while interacting with a broker.
+    #[error("error while interacting with a broker: {0:?}")]
+    BrokerError(BrokerRequestError),
+    /// The client is disconnected.
+    #[error("the client is disconnected")]
+    Disconnected,
+    /// Error while encoding a batch of records.
+    #[error("error while encoding a batch of records: {0}")]
+    EncodingError(String),
+    /// The specified topic has no available partitions.
+    #[error("the specified topic has no available partitions: {0}")]
+    NoPartitionsAvailable(String),
+    /// A broker has disappeared from the cluster during client operations.
+    ///
+    /// Typically, application code should just retry the request in the face of this error.
+    #[error("broker has disappeared from the cluster during client operations: {0:?}")]
+    UnknownBroker(BrokerId),
+    /// The specified topic is unknown to the cluster.
+    #[error("the specified topic is unknown to the cluster: {0}")]
+    UnknownTopic(String),
+}
+
+/// A producer for a specific topic.
+///
+/// This producer is `Send + Sync + Clone`, and cloning this producer to share it among application
+/// tasks is encouraged.
+pub struct TopicProducer {
+    /// The client handle from which this producer was created.
+    _client: Client,
+    /// The channel used by this producer.
+    tx: mpsc::UnboundedSender<BrokerResponse>,
+    /// The channel used by this producer.
+    rx: mpsc::UnboundedReceiver<BrokerResponse>,
+    /// Discovered metadata on a Kafka cluster along with broker connections.
+    ///
+    /// NOTE WELL: this value should never be updated outside of the `ClientTask`.
+    cluster: ClusterMeta,
+    /// The topic being produced to.
+    topic: StrBytes,
+    /// Acks level to use for produce requests.
+    acks: Acks,
+    /// Timeout for produce requests.
+    timeout_ms: i32,
+    /// Record batch encoding config.
+    encode_opts: RecordEncodeOptions,
+
+    /// A buffer used for encoding batches.
+    buf: BytesMut,
+    /// A buffer to accumulating records to be sent to a broker.
+    batch_buf: Vec<Record>,
+    /// The last partition used for round-robin or uniform sticky batch assignment.
+    last_ptn: i32,
+}
+
+impl TopicProducer {
+    /// Produce a batch of records to the specified topic.
+    pub async fn produce(&mut self, messages: &[Message]) -> Result<()> {
+        // TODO: allow for producer to specify partition instead of using sticky rotating partitions.
+
+        // Check for topic metadata.
+        if messages.is_empty() {
+            return Ok(());
+        }
+        let mut cluster = self.cluster.load();
+        if !*cluster.bootstrap.borrow() {
+            let mut sig = cluster.bootstrap.clone();
+            let _ = sig.wait_for(|val| *val).await; // Ensure the cluster metadata is bootstrapped.
+            cluster = self.cluster.load();
+        }
+        let Some(topic_ptns) = cluster.topics.get(&self.topic) else {
+            return Err(ClientError::UnknownTopic(self.topic.to_string()));
+        };
+
+        // Target the next partition of this topic for this batch.
+        let Some((sticky_ptn, sticky_broker)) = topic_ptns
+            .range((self.last_ptn + 1)..)
+            .next()
+            .or_else(|| topic_ptns.range(..).next())
+            .map(|(key, val)| (*key, val.clone()))
+        else {
+            return Err(ClientError::NoPartitionsAvailable(self.topic.to_string()));
+        };
+        self.last_ptn = sticky_ptn;
+
+        // Transform the given messages into their record form.
+        let timestamp = chrono::Utc::now().timestamp();
+        for msg in messages.iter() {
+            self.batch_buf.push(Record {
+                transactional: false,
+                control: false,
+                partition_leader_epoch: 0,
+                producer_id: 0,
+                producer_epoch: 0,
+                timestamp,
+                timestamp_type: TimestampType::Creation,
+                offset: 0,
+                sequence: 0,
+                key: msg.key.clone(),
+                value: msg.value.clone(),
+                headers: msg.headers.clone(),
+            });
+        }
+
+        // Encode the records into a request.
+        // TODO: until https://github.com/tychedelia/kafka-protocol-rs/issues/55 is g2g, we overestimate a bit.
+        let size = self.batch_buf.iter().fold(0usize, |mut acc, record| {
+            acc += 21; // Max size of the varint encoded values in a v2 record.
+            if let Some(key) = record.key.as_ref() {
+                acc += key.len();
+            }
+            if let Some(val) = record.value.as_ref() {
+                acc += val.len();
+            }
+            for (k, v) in record.headers.iter() {
+                acc += 4 + k.len() + 4 + v.as_ref().map(|v| v.len()).unwrap_or(0);
+            }
+            acc
+        });
+        self.buf.reserve(size);
+        RecordBatchEncoder::encode(&mut self.buf, self.batch_buf.iter(), &self.encode_opts).map_err(|err| ClientError::EncodingError(format!("{:?}", err)))?;
+
+        // Create the request object for the broker.
+        let mut req = ProduceRequest::default();
+        req.acks = self.acks as i16;
+        req.timeout_ms = self.timeout_ms;
+        let topic = req.topic_data.entry(self.topic.clone().into()).or_default();
+        let mut ptn_data = PartitionProduceData::default();
+        ptn_data.index = sticky_ptn;
+        ptn_data.records = Some(self.buf.split().freeze());
+        topic.partition_data.push(ptn_data);
+
+        // Send off request & await response.
+        let uid = uuid::Uuid::new_v4();
+        sticky_broker.conn.produce(uid, req, self.tx.clone()).await;
+        let res = loop {
+            let Some(res) = self.rx.recv().await else {
+                unreachable!("both ends of channel are heald, receiving None should not be possible")
+            };
+            if res.id == uid {
+                break res;
+            }
+        };
+
+        // Handle response.
+        res.result
+            .map(|response| tracing::debug!(?response, "success producing data to topic partition"))
+            .map_err(ClientError::BrokerError)
     }
 }

--- a/src/clitask.rs
+++ b/src/clitask.rs
@@ -4,24 +4,70 @@
 //! of this library.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use kafka_protocol::messages::metadata_response::MetadataResponseBroker;
-use kafka_protocol::messages::{BrokerId, MetadataResponse, TopicName};
-use tokio::sync::mpsc;
+use kafka_protocol::messages::{BrokerId, MetadataResponse, ResponseKind};
+use kafka_protocol::protocol::StrBytes;
+use tokio::sync::{mpsc, watch};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::broker::{Broker, BrokerMeta};
+use crate::broker::{Broker, BrokerConnInfo, BrokerPtr, BrokerResponse};
 
-/// A message from a client.
-pub enum ClientMsg {}
+/// Discovered metadata on a Kafka cluster along with broker connections.
+///
+/// NOTE WELL: this value should never be updated outside of the `ClientTask`.
+pub(crate) type ClusterMeta = Arc<ArcSwap<Cluster>>;
+
+/// Discovered metadata on a Kafka cluster along with broker connections.
+#[derive(Clone, Debug)]
+pub(crate) struct Cluster {
+    /// A signal indicating if the cluster's metadata has been fetched at least once.
+    pub(crate) bootstrap: watch::Receiver<bool>,
+    /// Broker connections and metadata of all discovered cluster brokers.
+    pub(crate) brokers: BTreeMap<BrokerId, BrokerMetaPtr>,
+    /// All topics which have been discovered from cluster metadata queries.
+    pub(crate) topics: BTreeMap<StrBytes, BTreeMap<i32, BrokerMetaPtr>>,
+}
+
+impl Cluster {
+    /// Construct a new instance.
+    fn new(bootstrap: watch::Receiver<bool>) -> Self {
+        Self {
+            bootstrap,
+            brokers: Default::default(),
+            topics: Default::default(),
+        }
+    }
+}
+
+/// Metadata and connection to a Kafka broker.
+pub(crate) type BrokerMetaPtr = Arc<BrokerMeta>;
+
+/// Metadata and connection to a Kafka broker.
+pub(crate) struct BrokerMeta {
+    /// The ID of a broker.
+    pub(crate) id: BrokerId,
+    /// The connection to the broker.
+    pub(crate) conn: BrokerPtr,
+    /// The cluster metadata of the broker.
+    pub(crate) meta: MetadataResponseBroker,
+}
+
+impl std::fmt::Debug for BrokerMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BrokerMeta").field("id", &self.id).field("meta", &self.meta).finish()
+    }
+}
 
 /// An async task which owns all interaction with a Kafka cluster.
 ///
 /// Client tasks have a corresponding frontend `Client` which is used to drive interaction with
 /// the target Kafka cluster.
-pub struct ClientTask {
+pub(crate) struct ClientTask {
     /// The starting list of brokers to connect to for metadata.
     ///
     /// The seed list is only used to establish initial connections to the Kafka cluster.
@@ -29,31 +75,35 @@ pub struct ClientTask {
     /// the returned metadata will be used for all following client connections.
     seed_list: Vec<String>,
     /// The channel used for receiving client interaction requests.
-    rx: mpsc::Receiver<ClientMsg>,
+    rx: mpsc::Receiver<Msg>,
+    /// The channel used for receiving responses from brokers.
+    resp_tx: mpsc::UnboundedSender<BrokerResponse>,
+    /// The channel used for receiving responses from brokers.
+    resp_rx: mpsc::UnboundedReceiver<BrokerResponse>,
+    /// Cluster metadata bootstrap signal.
+    bootstrap_tx: watch::Sender<bool>,
     /// Client shutdown signal.
     shutdown: CancellationToken,
 
-    /// All topics which have been discovered from cluster metadata queries.
-    topics: BTreeMap<TopicName, BTreeMap<i32, BrokerId>>,
-    /// Connections to discovered brokers.
-    brokers: BTreeMap<BrokerId, Broker>,
-    /// All brokers which have been discovered from cluster metadata queries.
-    brokers_meta: BTreeMap<BrokerId, MetadataResponseBroker>,
-    /// All topic/partitions per broker.
-    broker_ptns: BTreeMap<BrokerId, Vec<(TopicName, i32)>>,
+    /// Discovered metadata on a Kafka cluster along with broker connections.
+    ///
+    /// NOTE WELL: this value should never be updated outside of the `ClientTask`.
+    pub(crate) cluster: ClusterMeta,
 }
 
 impl ClientTask {
     /// Construct a new instance.
-    pub(crate) fn new(seed_list: Vec<String>, rx: mpsc::Receiver<ClientMsg>, shutdown: CancellationToken) -> Self {
+    pub(crate) fn new(seed_list: Vec<String>, rx: mpsc::Receiver<Msg>, shutdown: CancellationToken) -> Self {
+        let (bootstrap_tx, bootstrap_rx) = watch::channel(false);
+        let (resp_tx, resp_rx) = mpsc::unbounded_channel();
         Self {
             seed_list,
             rx,
+            resp_tx,
+            resp_rx,
+            cluster: Arc::new(ArcSwap::new(Arc::new(Cluster::new(bootstrap_rx.clone())))),
+            bootstrap_tx,
             shutdown,
-            topics: BTreeMap::default(),
-            brokers: BTreeMap::default(),
-            brokers_meta: BTreeMap::default(),
-            broker_ptns: BTreeMap::default(),
         }
     }
 
@@ -72,8 +122,9 @@ impl ClientTask {
         tracing::debug!("kafka client has shutdown");
     }
 
-    async fn handle_client_msg(&mut self, msg: ClientMsg) {
-        todo!()
+    async fn handle_client_msg(&mut self, _msg: Msg) {
+        // TODO: probably will only need this for fetching updated cluster metadata and such.
+        // TODO: setup an interval for fetching updated metadata from cluster.
     }
 
     /// Bootstrap cluster connections, API versions, and metadata, all from the starting seed list of brokers.
@@ -88,17 +139,35 @@ impl ClientTask {
 
                 // We have a connection object which will gather API versions info on its own (straightaway).
                 // Now, just fetch cluster metadata info.
-                let conn = Broker::new(BrokerMeta::Host(host));
-                let meta = match conn.get_metadata().await {
-                    Ok(meta) => meta,
+                let conn = Broker::new(BrokerConnInfo::Host(host));
+                let uid = uuid::Uuid::new_v4();
+                conn.get_metadata(uid, self.resp_tx.clone()).await;
+
+                // Await response from broker.
+                let res = loop {
+                    let Some(res) = self.resp_rx.recv().await else {
+                        unreachable!("both ends of channel are heald, receiving None should not be possible")
+                    };
+                    if res.id == uid {
+                        break res;
+                    }
+                };
+
+                let (_, res) = match res.result {
+                    Ok(res) => res,
                     Err(err) => {
-                        tracing::warn!(error = ?err, "error fetching metadata from broker");
+                        tracing::error!(error = ?err, "error fetching metadata for cluster");
                         continue;
                     }
+                };
+                let ResponseKind::MetadataResponse(meta) = res else {
+                    tracing::error!("malformed response received from cluster, expected a metadata response, got {:?}", res);
+                    continue;
                 };
 
                 // Establish connections to any newly discovered brokers.
                 self.update_cluster_metadata(meta);
+                let _ = self.bootstrap_tx.send(true);
                 return; // We only need 1 initial payload of metadata, so return here.
             }
 
@@ -111,37 +180,40 @@ impl ClientTask {
     }
 
     /// Update the cluster metadata in response to a metadata fetch on a broker.
+    #[allow(clippy::mutable_key_type)]
     fn update_cluster_metadata(&mut self, meta: MetadataResponse) {
-        // Update broker metadata.
-        self.brokers_meta.clear();
-        for (id, broker) in meta.brokers {
-            self.brokers_meta.insert(id, broker);
+        let mut cluster_ptr = self.cluster.load_full();
+        let cluster = Arc::make_mut(&mut cluster_ptr);
+
+        // Establish connections to any new brokers.
+        cluster.brokers.retain(|id, _| meta.brokers.contains_key(id)); // Remove brokers which no longer exist.
+        for (id, meta) in meta.brokers {
+            let broker_opt = cluster.brokers.get(&id);
+            let needs_update = broker_opt.map(|_meta| _meta.meta != meta).unwrap_or(true);
+            if needs_update {
+                let conn = Broker::new(meta.clone());
+                cluster.brokers.insert(id, Arc::new(BrokerMeta { id, conn, meta }));
+            }
         }
 
-        // Update topic partitions along with their broker leader.
-        self.topics.clear();
-        self.broker_ptns.clear();
+        // Update topic partitions along with their broker leader. We have to clear the map and re-build
+        // in order to ensure that we are not holding onto old broker ptrs (same ID, different connection/metadata).
+        cluster.topics.clear();
         for (id, topic) in meta.topics {
             for ptn in topic.partitions {
                 if ptn.error_code != 0 {
                     continue;
                 };
-                let topic_ptns = self.topics.entry(id.clone()).or_default();
-                topic_ptns.insert(ptn.partition_index, ptn.leader_id);
-                let broker_ptns = self.broker_ptns.entry(ptn.leader_id).or_default();
-                broker_ptns.push((id.clone(), ptn.partition_index));
+                let ptns = cluster.topics.entry(id.0.clone()).or_default();
+                if let Some(broker) = cluster.brokers.get(&ptn.leader_id).cloned() {
+                    ptns.insert(ptn.partition_index, broker);
+                }
             }
         }
-
-        // Establish connections to any new brokers.
-        for (id, meta) in self.brokers_meta.iter() {
-            if !self.brokers.contains_key(id) {
-                let broker = Broker::new(meta.clone());
-                self.brokers.insert(*id, broker);
-            }
-        }
-        self.brokers.retain(|id, _| self.brokers_meta.contains_key(id)); // Remove old brokers.
-
-        tracing::debug!(?self.brokers_meta, ?self.topics, ?self.broker_ptns, "cluster metadata updated");
+        tracing::debug!(?cluster, "cluster metadata updated");
+        self.cluster.store(cluster_ptr);
     }
 }
+
+/// A message from a client.
+pub(crate) enum Msg {}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -61,10 +61,10 @@ pub(crate) struct Request {
     pub kind: RequestKind,
 }
 
-impl Encoder<Request> for KafkaCodecWriter {
+impl Encoder<&'_ Request> for KafkaCodecWriter {
     type Error = anyhow::Error;
 
-    fn encode(&mut self, item: Request, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: &'_ Request, dst: &mut BytesMut) -> Result<(), Self::Error> {
         // Compute the encoding size of the header.
         let key = ApiKey::try_from(item.header.request_api_key).map_err(|_| anyhow::anyhow!("unknown API key"))?;
         let header_version = key.request_header_version(item.header.request_api_version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,10 @@ mod client;
 mod clitask;
 mod codec;
 
-pub use client::Client;
-pub use kafka_protocol as proto;
+pub use kafka_protocol;
+pub use kafka_protocol::indexmap;
+
+pub use client::{Acks, Client, Message};
+pub use kafka_protocol::indexmap::IndexMap;
+pub use kafka_protocol::protocol::StrBytes;
+pub use kafka_protocol::records::Compression;


### PR DESCRIPTION
Core client is responsible for managing the lifecycle of cluster bootstrapping, API versions, metadata discovery, connecting to new brokers, reconnecting upon transient errors, and so on.

The core client is a series of tasks which cooperate together to provide a uniform, topic-oriented interface to the backing Kafka cluster.

For every topic that an app needs to publish to, a TopicProducer may be created which multiplexes all of its broker interaction over the same TCP connections of the core client.

The TopicProducer exclusively uses the uniform sticky producer strategy, for performance, atomicity, efficiency, and simplicity. The target partition is rotated after every interaction to ensure distribution of load across partitions.