### PR TITLE
Implement primitive ListOffsets & Fetch methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka-rs"
 description = "Native Rust Kafka client, built upon kafka-protocol-rs and Tokio."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>"]

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -1,13 +1,13 @@
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use kafka_rs::{Acks, Client, Compression, Message};
+use kafka_rs::{Acks, Client, Compression, ListOffsetsPosition, Message, StrBytes};
 use tracing_subscriber::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::registry()
         // Filter spans based on the RUST_LOG env var.
-        .with(tracing_subscriber::EnvFilter::new("error,kafka_rs=debug"))
+        .with(tracing_subscriber::EnvFilter::new("error,simple_producer=debug,kafka_rs=debug"))
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false) // Too verbose, so disable target.
@@ -18,11 +18,22 @@ async fn main() -> Result<()> {
         .try_init()
         .expect("error initializing tracing");
 
+    let topic = StrBytes::from_string(std::env::var("TOPIC").context("TOPIC env var must be specified")?);
     let cli = Client::new(vec!["localhost:9092".into()]);
-    let mut producer = cli.topic_producer("testing", Acks::All, None, Some(Compression::Snappy));
 
+    // Fetch the starting position of the target topic.
+    let start = cli.list_offsets(topic.clone(), 0, ListOffsetsPosition::Earliest).await.context("error listing offsets")?;
+    tracing::info!(start, "found log start");
+
+    // Produce some data.
+    let mut producer = cli.topic_producer(topic.as_str(), Acks::All, None, Some(Compression::Snappy));
     let messages = vec![Message::new(Some("key0".into()), Some(Bytes::from_static(b"val0")), Default::default())];
     let (first_offset, last_offset) = producer.produce(&messages).await.context("error producing data to cluster")?;
     tracing::info!("first_offset={}; last_offset={}", first_offset, last_offset);
+
+    // Fetch the same data back.
+    let records = cli.fetch(topic.clone(), 0, 0).await.context("error fetching batch")?;
+    tracing::info!(?records, "fetched batch");
+
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,9 @@
 
 use kafka_protocol::messages::RequestKind;
 
+/// Client results from interaction with a Kafka cluster.
+pub type ClientResult<T> = std::result::Result<T, ClientError>;
+
 /// Client errors from interacting with a Kafka cluster.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -23,6 +26,11 @@ pub enum ClientError {
     /// The specified topic is unknown to the cluster.
     #[error("the specified topic is unknown to the cluster: {0}")]
     UnknownTopic(String),
+    /// The specified topic partition is unknown to the cluster.
+    #[error("the specified topic partition is unknown to the cluster: {0}/{1}")]
+    UnknownPartition(String, i32),
+    #[error("{0}")]
+    Other(String),
 }
 
 /// Broker connection level error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod error;
 pub use kafka_protocol;
 pub use kafka_protocol::indexmap;
 
-pub use client::{Acks, Client, Message, TopicProducer};
+pub use client::{Acks, Client, ListOffsetsPosition, Message, TopicProducer};
 pub use kafka_protocol::indexmap::IndexMap;
 pub use kafka_protocol::protocol::StrBytes;
 pub use kafka_protocol::records::Compression;


### PR DESCRIPTION
These primitive methods are useful on their own, but will also be used to build some of the higher-level types, such as consumer groups.