### PR TITLE
Expose producer topic field & fix an off by 1 bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka-rs"
 description = "Native Rust Kafka client, built upon kafka-protocol-rs and Tokio."
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -252,7 +252,7 @@ pub struct TopicProducer {
     /// NOTE WELL: this value should never be updated outside of the `ClientTask`.
     cluster: ClusterMeta,
     /// The topic being produced to.
-    topic: StrBytes,
+    pub topic: StrBytes,
     /// Acks level to use for produce requests.
     acks: Acks,
     /// Timeout for produce requests.
@@ -378,7 +378,13 @@ impl TopicProducer {
                 res.responses
                     .iter()
                     .find(|topic| topic.0 .0 == self.topic)
-                    .and_then(|val| val.1.partition_responses.first().map(|val| (val.base_offset, val.base_offset + messages.len() as i64)))
+                    .and_then(|val| {
+                        val.1.partition_responses.first().map(|val| {
+                            debug_assert!(messages.len() > 0, "messages len should always be validated at start of function");
+                            let last_offset = val.base_offset + (messages.len() - 1) as i64;
+                            (val.base_offset, last_offset)
+                        })
+                    })
                     .ok_or(ClientError::MalformedResponse)
             })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub use kafka_protocol::indexmap;
 pub use client::{Acks, Client, ListOffsetsPosition, Message, TopicProducer};
 pub use kafka_protocol::indexmap::IndexMap;
 pub use kafka_protocol::protocol::StrBytes;
-pub use kafka_protocol::records::Compression;
+pub use kafka_protocol::records::{Compression, Record};


### PR DESCRIPTION
When the producer receives a response from the broker, calculating the start & stop offsets of the batch's messages was off by 1.