### PR TITLE
Add broker_request macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka-rs"
 description = "Native Rust Kafka client, built upon kafka-protocol-rs and Tokio."
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>"]

--- a/examples/create_topic.rs
+++ b/examples/create_topic.rs
@@ -22,10 +22,10 @@ async fn main() -> Result<()> {
     let topic = StrBytes::from_string(std::env::var("TOPIC").context("TOPIC env var must be specified")?);
     let host = std::env::var("HOST").context("HOST env var must be specified")?;
     let port = std::env::var("PORT").context("PORT env var must be specified")?;
-    let cli = Client::new(vec![(host + ":" + &port).into()]);
+    let cli = Client::new(vec![format!("{}:{}", host, port)]);
 
     // Create new topic.
-    let mut admin = cli.admin();
+    let admin = cli.admin();
 
     let mut ctb = CreatableTopicBuilder::default();
     ctb.replication_factor(1);

--- a/examples/delete_topic.rs
+++ b/examples/delete_topic.rs
@@ -23,11 +23,10 @@ async fn main() -> Result<()> {
     let topic = StrBytes::from_string(std::env::var("TOPIC").context("TOPIC env var must be specified")?);
     let host = std::env::var("HOST").context("HOST env var must be specified")?;
     let port = std::env::var("PORT").context("PORT env var must be specified")?;
-    let cli = Client::new(vec![(host + ":" + &port).into()]);
+    let cli = Client::new(vec![format!("{}:{}", host, port)]);
 
     // Create new topic.
     let admin = cli.admin();
-
     let mut ctb = CreatableTopicBuilder::default();
     ctb.replication_factor(1);
     ctb.num_partitions(1);
@@ -42,7 +41,6 @@ async fn main() -> Result<()> {
     admin.create_topics(req).await.context("error creating topic")?;
 
     // Now delete it!
-
     let topic = StrBytes::from_string(std::env::var("TOPIC").context("TOPIC env var must be specified")?);
     let mut dtsb = DeleteTopicStateBuilder::default();
     dtsb.name(Some(TopicName(topic)));


### PR DESCRIPTION
This PR adds a `broker_request` macro to generate the various `BrokerTask` associated functions. This greatly eliminates the boilerplate we need to set these up.